### PR TITLE
Use 7.0.3 of xunit-viewer, which properly exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Pinned `xunit-viewer` to `7.0.3` so that it properly exits
 
 ### Deprecated
 

--- a/template_updater/extraction.Dockerfile
+++ b/template_updater/extraction.Dockerfile
@@ -1,21 +1,20 @@
 FROM node:latest
 
 # first install software
-RUN npm i -g xunit-viewer
+RUN npm i -g xunit-viewer@7.0.3
 
 # create dummy input placeholder
 RUN echo "<testsuite><testcase name='foo'></testcase></testsuite>" > blarg.xml
 
 # accept a name for the output report, ".html" automatically appended if not already there!
-ARG OUTPUT_HTML_NAME=report_template
-RUN timeout 5 xunit-viewer \
+ARG OUTPUT_HTML_NAME=report_template.html
+RUN xunit-viewer \
   --server false \
   --watch false \
   --output $OUTPUT_HTML_NAME \
   --title BLARG_TITLE \
   --brand BLARG_BRAND \
   --favicon BLARG_FAVICON \
-  --results blarg.xml \
-  ; true
+  --results blarg.xml
 
 RUN echo $OUTPUT_HTML_NAME && test -f $OUTPUT_HTML_NAME


### PR DESCRIPTION
Use a fixed version of the underlying npm package
https://github.com/lukejpreston/xunit-viewer/issues/98#issuecomment-818813910

This removes the need for an arbitrary timeout in the script that generates the template